### PR TITLE
Add driver for generic HID joysticks/gamepads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ OSVERSION!=	awk '/^\#define[[:space:]]*__FreeBSD_version/ { print $$3 }' \
 
 KMOD	= iichid
 SRCS	= iichid.c iichid.h
-SRCS	+= hconf.c hconf.h hms.c hmt.c hpen.c hsctrl.c hcons.c
+SRCS	+= hconf.c hconf.h hgame.c hms.c hmt.c hpen.c hsctrl.c hcons.c
 SRCS	+= hidbus.c hidbus.h hid_if.c hid_if.h hid.c hid.h hid_lookup.c
 SRCS	+= hid_debug.h hid_debug.c
 SRCS	+= hmap.h hmap.c

--- a/hgame.c
+++ b/hgame.c
@@ -59,77 +59,74 @@ SYSCTL_INT(_hw_hid_hgame, OID_AUTO, debug, CTLFLAG_RWTUN,
 		&hgame_debug, 0, "Debug level");
 #endif
 
-static hmap_cb_t	hgame_button_cb;
-
-#define HGAME_MAP_BUT(usage)	\
-	HMAP_ABS_CB(#usage, HID_USAGE2(HUP_BUTTON, usage), hgame_button_cb)
+#define HGAME_MAP_BUT(base, number)	\
+	HMAP_KEY(#number, HID_USAGE2(HUP_BUTTON, number), base + number - 1)
 #define HGAME_MAP_ABS(usage, code)        \
 	HMAP_ABS(#usage, HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_##usage), code)
 
-static const struct hmap_item hgame_map[] = {
-	{ HGAME_MAP_BUT(1) },
-	{ HGAME_MAP_BUT(2) },
-	{ HGAME_MAP_BUT(3) },
-	{ HGAME_MAP_BUT(4) },
-	{ HGAME_MAP_BUT(5) },
-	{ HGAME_MAP_BUT(6) },
-	{ HGAME_MAP_BUT(7) },
-	{ HGAME_MAP_BUT(8) },
-	{ HGAME_MAP_BUT(9) },
-	{ HGAME_MAP_BUT(10) },
-	{ HGAME_MAP_BUT(11) },
-	{ HGAME_MAP_BUT(12) },
-	{ HGAME_MAP_BUT(13) },
-	{ HGAME_MAP_BUT(14) },
-	{ HGAME_MAP_BUT(15) },
-	{ HGAME_MAP_BUT(16) },
-	{ HGAME_MAP_BUT(17) },
-	{ HGAME_MAP_BUT(18) },
-	{ HGAME_MAP_BUT(19) },
-	{ HGAME_MAP_BUT(20) },
-	{ HGAME_MAP_BUT(21) },
-	{ HGAME_MAP_BUT(22) },
-	{ HGAME_MAP_BUT(23) },
-	{ HGAME_MAP_BUT(24) },
+#define BASE_OVERFLOW (BTN_TRIGGER_HAPPY - 0x10)
 
-	{ HGAME_MAP_ABS(X, ABS_X) },
-	{ HGAME_MAP_ABS(Y, ABS_Y) },
-	{ HGAME_MAP_ABS(Z, ABS_Z) },
-	{ HGAME_MAP_ABS(RX, ABS_RX) },
-	{ HGAME_MAP_ABS(RY, ABS_RY) },
-	{ HGAME_MAP_ABS(RZ, ABS_RZ) },
+#define COMMON_ITEMS \
+	{ HGAME_MAP_BUT(BASE_OVERFLOW, 17) }, \
+	{ HGAME_MAP_BUT(BASE_OVERFLOW, 18) }, \
+	{ HGAME_MAP_BUT(BASE_OVERFLOW, 19) }, \
+	{ HGAME_MAP_BUT(BASE_OVERFLOW, 20) }, \
+	{ HGAME_MAP_BUT(BASE_OVERFLOW, 21) }, \
+	{ HGAME_MAP_BUT(BASE_OVERFLOW, 22) }, \
+	{ HGAME_MAP_BUT(BASE_OVERFLOW, 23) }, \
+	{ HGAME_MAP_BUT(BASE_OVERFLOW, 24) }, \
+	{ HGAME_MAP_ABS(X, ABS_X) }, \
+	{ HGAME_MAP_ABS(Y, ABS_Y) }, \
+	{ HGAME_MAP_ABS(Z, ABS_Z) }, \
+	{ HGAME_MAP_ABS(RX, ABS_RX) }, \
+	{ HGAME_MAP_ABS(RY, ABS_RY) }, \
+	{ HGAME_MAP_ABS(RZ, ABS_RZ) }, \
 	{ HGAME_MAP_ABS(HAT_SWITCH, ABS_HAT0X) },
+
+static const struct hmap_item hgame_joystick_map[] = {
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 1) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 2) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 3) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 4) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 5) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 6) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 7) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 8) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 9) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 10) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 11) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 12) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 13) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 14) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 15) },
+	{ HGAME_MAP_BUT(BTN_TRIGGER, 16) },
+	COMMON_ITEMS
+};
+
+static const struct hmap_item hgame_gamepad_map[] = {
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 1) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 2) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 3) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 4) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 5) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 6) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 7) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 8) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 9) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 10) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 11) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 12) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 13) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 14) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 15) },
+	{ HGAME_MAP_BUT(BTN_GAMEPAD, 16) },
+	COMMON_ITEMS
 };
 
 static const struct hid_device_id hgame_devs[] = {
 	{ HID_TLC(HUP_GENERIC_DESKTOP, HUG_JOYSTICK), HID_DRIVER_INFO(HUG_JOYSTICK) },
 	{ HID_TLC(HUP_GENERIC_DESKTOP, HUG_GAME_PAD), HID_DRIVER_INFO(HUG_GAME_PAD) },
 };
-
-static void
-hgame_button_cb(HMAP_CB_ARGS)
-{
-	struct hmap_softc *sc = HMAP_CB_GET_SOFTC;
-	struct evdev_dev *evdev = HMAP_CB_GET_EVDEV;
-	const uint16_t btn = (HMAP_CB_GET_MAP_ITEM->usage & 0xffff) - 1;
-	uint16_t base = BTN_TRIGGER; /* == BTN_JOYSTICK */
-	int32_t data;
-
-	if (hidbus_get_driver_info(sc->dev) == HUG_GAME_PAD)
-		base = BTN_GAMEPAD;
-
-	/* First button over 16 is BTN_TRIGGER_HAPPY */
-	if (btn >= 0x10)
-		base = BTN_TRIGGER_HAPPY - 0x10;
-
-	if (HMAP_CB_IS_ATTACHING) {
-		evdev_support_event(evdev, EV_KEY);
-		evdev_support_key(evdev, base + btn);
-	} else {
-		data = ctx;
-		evdev_push_key(evdev, base + btn, data);
-	}
-}
 
 static int
 hgame_probe(device_t dev)
@@ -142,8 +139,10 @@ hgame_probe(device_t dev)
 
 	hmap_set_debug_var(dev, &HID_DEBUG_VAR);
 
-	/* Check if report descriptor belongs to a HID joystick device */
-	error = hmap_add_map(dev, hgame_map, nitems(hgame_map), NULL);
+	if (hidbus_get_driver_info(dev) == HUG_GAME_PAD)
+		error = hmap_add_map(dev, hgame_gamepad_map, nitems(hgame_gamepad_map), NULL);
+	else
+		error = hmap_add_map(dev, hgame_joystick_map, nitems(hgame_joystick_map), NULL);
 	if (error != 0)
 		return (error);
 

--- a/hgame.c
+++ b/hgame.c
@@ -1,0 +1,170 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause-FreeBSD
+ *
+ * Copyright (c) 2020 Vladimir Kondratyev <wulf@FreeBSD.org>
+ * Copyright (c) 2020 Greg V <greg@unrelenting.technology>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+/*
+ * Generic HID game controller (joystick/gamepad) driver
+ *
+ */
+
+#include <sys/param.h>
+#include <sys/bus.h>
+#include <sys/kernel.h>
+#include <sys/module.h>
+#include <sys/sysctl.h>
+
+#include <dev/evdev/input.h>
+#include <dev/evdev/evdev.h>
+
+#include "hid.h"
+#include "hidbus.h"
+#include "hmap.h"
+
+#define	HID_DEBUG_VAR	hgame_debug
+#include "hid_debug.h"
+
+#ifdef HID_DEBUG
+static int hgame_debug = 1;
+
+static SYSCTL_NODE(_hw_hid, OID_AUTO, hgame, CTLFLAG_RW, 0,
+		"Generic HID joystick/gamepad");
+SYSCTL_INT(_hw_hid_hgame, OID_AUTO, debug, CTLFLAG_RWTUN,
+		&hgame_debug, 0, "Debug level");
+#endif
+
+static hmap_cb_t	hgame_button_cb;
+
+#define HGAME_MAP_BUT(usage)	\
+	HMAP_ABS_CB(#usage, HID_USAGE2(HUP_BUTTON, usage), hgame_button_cb)
+#define HGAME_MAP_ABS(usage, code)        \
+	HMAP_ABS(#usage, HID_USAGE2(HUP_GENERIC_DESKTOP, HUG_##usage), code)
+
+static const struct hmap_item hgame_map[] = {
+	{ HGAME_MAP_BUT(1) },
+	{ HGAME_MAP_BUT(2) },
+	{ HGAME_MAP_BUT(3) },
+	{ HGAME_MAP_BUT(4) },
+	{ HGAME_MAP_BUT(5) },
+	{ HGAME_MAP_BUT(6) },
+	{ HGAME_MAP_BUT(7) },
+	{ HGAME_MAP_BUT(8) },
+	{ HGAME_MAP_BUT(9) },
+	{ HGAME_MAP_BUT(10) },
+	{ HGAME_MAP_BUT(11) },
+	{ HGAME_MAP_BUT(12) },
+	{ HGAME_MAP_BUT(13) },
+	{ HGAME_MAP_BUT(14) },
+	{ HGAME_MAP_BUT(15) },
+	{ HGAME_MAP_BUT(16) },
+	{ HGAME_MAP_BUT(17) },
+	{ HGAME_MAP_BUT(18) },
+	{ HGAME_MAP_BUT(19) },
+	{ HGAME_MAP_BUT(20) },
+	{ HGAME_MAP_BUT(21) },
+	{ HGAME_MAP_BUT(22) },
+	{ HGAME_MAP_BUT(23) },
+	{ HGAME_MAP_BUT(24) },
+
+	{ HGAME_MAP_ABS(X, ABS_X) },
+	{ HGAME_MAP_ABS(Y, ABS_Y) },
+	{ HGAME_MAP_ABS(Z, ABS_Z) },
+	{ HGAME_MAP_ABS(RX, ABS_RX) },
+	{ HGAME_MAP_ABS(RY, ABS_RY) },
+	{ HGAME_MAP_ABS(RZ, ABS_RZ) },
+	{ HGAME_MAP_ABS(HAT_SWITCH, ABS_HAT0X) },
+};
+
+static const struct hid_device_id hgame_devs[] = {
+	{ HID_TLC(HUP_GENERIC_DESKTOP, HUG_JOYSTICK), HID_DRIVER_INFO(HUG_JOYSTICK) },
+	{ HID_TLC(HUP_GENERIC_DESKTOP, HUG_GAME_PAD), HID_DRIVER_INFO(HUG_GAME_PAD) },
+};
+
+static void
+hgame_button_cb(HMAP_CB_ARGS)
+{
+	struct hmap_softc *sc = HMAP_CB_GET_SOFTC;
+	struct evdev_dev *evdev = HMAP_CB_GET_EVDEV;
+	const uint16_t btn = (HMAP_CB_GET_MAP_ITEM->usage & 0xffff) - 1;
+	uint16_t base = BTN_TRIGGER; /* == BTN_JOYSTICK */
+	int32_t data;
+
+	if (hidbus_get_driver_info(sc->dev) == HUG_GAME_PAD)
+		base = BTN_GAMEPAD;
+
+	/* First button over 16 is BTN_TRIGGER_HAPPY */
+	if (btn >= 0x10)
+		base = BTN_TRIGGER_HAPPY - 0x10;
+
+	if (HMAP_CB_IS_ATTACHING) {
+		evdev_support_event(evdev, EV_KEY);
+		evdev_support_key(evdev, base + btn);
+	} else {
+		data = ctx;
+		evdev_push_key(evdev, base + btn, data);
+	}
+}
+
+static int
+hgame_probe(device_t dev)
+{
+	int error;
+
+	error = hidbus_lookup_driver_info(dev, hgame_devs, sizeof(hgame_devs));
+	if (error != 0)
+		return (error);
+
+	hmap_set_debug_var(dev, &HID_DEBUG_VAR);
+
+	/* Check if report descriptor belongs to a HID joystick device */
+	error = hmap_add_map(dev, hgame_map, nitems(hgame_map), NULL);
+	if (error != 0)
+		return (error);
+
+	hmap_set_evdev_prop(dev, INPUT_PROP_DIRECT);
+	hidbus_set_desc(dev,
+		(hidbus_get_driver_info(dev) == HUG_GAME_PAD) ? "Gamepad" : "Joystick");
+
+	return (BUS_PROBE_DEFAULT);
+}
+
+static devclass_t hgame_devclass;
+
+static device_method_t hgame_methods[] = {
+	DEVMETHOD(device_probe, hgame_probe),
+	DEVMETHOD_END
+};
+
+DEFINE_CLASS_1(hgame, hgame_driver, hgame_methods,
+    sizeof(struct hmap_softc), hmap_driver);
+DRIVER_MODULE(hgame, hidbus, hgame_driver, hgame_devclass, NULL, 0);
+MODULE_DEPEND(hgame, hid, 1, 1, 1);
+MODULE_DEPEND(hgame, hmap, 1, 1, 1);
+MODULE_DEPEND(hgame, evdev, 1, 1, 1);
+MODULE_VERSION(hgame, 1);

--- a/hmap.c
+++ b/hmap.c
@@ -149,7 +149,7 @@ hmap_intr(void *context, void *buf, uint16_t len)
 
 		switch (hi->type) {
 		case HMAP_TYPE_CALLBACK:
-			hi->map->cb(sc, hi, data);
+			hi->map->cb(sc, hi->map, hi, data);
 			break;
 
 		case HMAP_TYPE_VARIABLE:
@@ -435,7 +435,7 @@ hmap_hid_parse(struct hmap_softc *sc, uint8_t tlc_index)
 			if (can_map_callback(&hi, mi)) {
 				item->map = mi;
 				item->type = HMAP_TYPE_CALLBACK;
-				mi->cb(sc, NULL, (intptr_t)&hi);
+				mi->cb(sc, mi, NULL, (intptr_t)&hi);
 				goto mapped;
 			}
 		}

--- a/hmap.h
+++ b/hmap.h
@@ -32,13 +32,15 @@
 #include <sys/bitstring.h>
 
 struct hmap_hid_item;
+struct hmap_item;
 struct hmap_softc;
 
 #define	HMAP_CB_ARGS	\
-	struct hmap_softc *super_sc, struct hmap_hid_item *hi, intptr_t ctx
+	struct hmap_softc *super_sc, const struct hmap_item *mi, struct hmap_hid_item *hi, intptr_t ctx
 #define	HMAP_CB_IS_ATTACHING	(hi == NULL)
 #define	HMAP_CB_GET_SOFTC	((void *)super_sc)
 #define	HMAP_CB_GET_EVDEV	(super_sc->evdev)
+#define	HMAP_CB_GET_MAP_ITEM	(mi)
 typedef void hmap_cb_t(HMAP_CB_ARGS);
 
 enum hmap_relabs {


### PR DESCRIPTION
Tested on an off-brand cheap USB gamepad with <16 buttons :D but I'm relatively confident in the lots-of-buttons (`BTN_TRIGGER_HAPPY`) support code.

The list of individual buttons in `struct hmap_item[]` sucks, would be nice to have a `.usage_mask` instead of `.usage` that would allow me to match all `HUP_BUTTON`s…