### PR TITLE
[hidraw] add /dev/uhidN alias

### DIFF
--- a/hidraw.c
+++ b/hidraw.c
@@ -212,6 +212,8 @@ hidraw_attach(device_t self)
 		return (error);
 	}
 
+	(void)make_dev_alias(sc->dev, "uhid%d", device_get_unit(self));
+
 	hidbus_set_intr(sc->sc_dev, hidraw_intr, sc);
 
 	return (0);


### PR DESCRIPTION
Because e.g. Firefox would not look for hidraw devices on FreeBSD right now.

ref: https://github.com/mozilla/authenticator-rs/pull/62

---

Tested with a Yubikey and Firefox. devd with u2f rules sets u2f group (and group write permission) on the hidraw devices, uhid aliases are symlinks without the group write permission but that seems fine — works in Firefox.