### PR TITLE
[DRAFT] iichid: add support for gpio interrupt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ SRCS	+= usbhid.c
 .endif
 SRCS	+= hidraw.c hidraw.h
 SRCS	+= hid_quirk.h hid_quirk.c
-SRCS	+= acpi_if.h bus_if.h device_if.h iicbus_if.h
+SRCS	+= acpi_if.h bus_if.h device_if.h iicbus_if.h gpio_if.h
 SRCS	+= opt_acpi.h opt_usb.h opt_evdev.h
 SRCS	+= strcasestr.c strcasestr.h
 # Revert 5d3a4a2 for compiling hkbd on pre 1300068 systems


### PR DESCRIPTION
This is a draft pull request just to show what I am working on.
Maybe I'll get some advise on the code.
Maybe the code will be useful as an example for some other work.

At the moment there is no support for GPIO interrupts on x86, but there is
some work in progress.
This change shows how to obtain GPIO interrupt configuration from ACPI
and to set up scuh an interrupt in a consumer driver.
The GPIO side of things will probably have some changes as the work
progresses.  The ACPI related code is probably fine already.