### PR TITLE
[xb360gp] invert analog stick Y axes

### DIFF
--- a/hidmap.c
+++ b/hidmap.c
@@ -244,6 +244,9 @@ hidmap_intr(void *context, void *buf, hid_size_t len)
 		DPRINTFN(hm, 6, "type=%d data=%d item=%*D\n", hi->type, data,
 		    (int)sizeof(hi->cb), &hi->cb, " ");
 
+		if (hi->invert_value)
+			data = ~data;
+
 		switch (hi->type) {
 		case HIDMAP_TYPE_CALLBACK:
 			if (hi->cb(hm, hi, (union hidmap_cb_ctx){.data = data})
@@ -589,6 +592,7 @@ hidmap_parse_hid_item(struct hidmap *hm, struct hid_item *hi,
 				    ? HIDMAP_TYPE_VAR_NULLST
 				    : HIDMAP_TYPE_VARIABLE;
 				item->last_val = 0;
+				item->invert_value = mi->invert_value;
 				switch (mi->type) {
 				case EV_KEY:
 					hidmap_support_key(hm, item->code);

--- a/hidmap.h
+++ b/hidmap.h
@@ -94,7 +94,8 @@ struct hidmap_item {
 	enum hidmap_relabs	relabs:2;
 	bool			has_cb:1;
 	bool			final_cb:1;
-	u_int			reserved:11;
+	bool			invert_value:1;
+	u_int			reserved:10;
 };
 
 #define	HIDMAP_ANY(_page, _usage, _type, _code)				\
@@ -177,6 +178,7 @@ struct hidmap_hid_item {
 	int32_t			lmax;		/* HID item logical maximum */
 	enum hidmap_type	type:8;
 	uint8_t			id;		/* Report ID */
+	bool			invert_value;
 };
 
 struct hidmap {

--- a/xb360gp.c
+++ b/xb360gp.c
@@ -70,6 +70,8 @@ static const uint8_t	xb360gp_rdesc[] = {UHID_XB360GP_REPORT_DESCR()};
 	{ HIDMAP_KEY(HUP_BUTTON, number, code) }
 #define XB360GP_MAP_ABS(usage, code)	\
 	{ HIDMAP_ABS(HUP_GENERIC_DESKTOP, HUG_##usage, code) }
+#define XB360GP_MAP_ABS_INV(usage, code)	\
+	{ HIDMAP_ABS(HUP_GENERIC_DESKTOP, HUG_##usage, code), .invert_value = 1 }
 #define XB360GP_MAP_CRG(usage_from, usage_to, callback)	\
 	{ HIDMAP_ANY_CB_RANGE(HUP_GENERIC_DESKTOP,	\
 	    HUG_##usage_from, HUG_##usage_to, callback) }
@@ -91,10 +93,10 @@ static const struct hidmap_item xb360gp_map[] = {
 	XB360GP_MAP_BUT(11,		BTN_MODE),
 	XB360GP_MAP_CRG(D_PAD_UP, D_PAD_LEFT, hgame_dpad_cb),
 	XB360GP_MAP_ABS(X,		ABS_X),
-	XB360GP_MAP_ABS(Y,		ABS_Y),
+	XB360GP_MAP_ABS_INV(Y,		ABS_Y),
 	XB360GP_MAP_ABS(Z,		ABS_Z),
 	XB360GP_MAP_ABS(RX,		ABS_RX),
-	XB360GP_MAP_ABS(RY,		ABS_RY),
+	XB360GP_MAP_ABS_INV(RY,		ABS_RY),
 	XB360GP_MAP_ABS(RZ,		ABS_RZ),
 	XB360GP_FINALCB(		hgame_final_cb),
 };


### PR DESCRIPTION
ref: https://github.com/paroj/xpad/blob/3935bf7ac186259f964aa163892f5eadbe1b9250/xpad.c#L642

---

So yeah I've just been remapping the Y axis as inverted in applications.. lol, let's fix this.
Hopefully the implementation is okay :)