### PR TITLE
DRAFT - Modify hmt to work with certain touch devices

### DIFF
--- a/hmt.c
+++ b/hmt.c
@@ -669,7 +669,7 @@ hmt_hid_parse(struct hmt_softc *sc, const void *d_ptr, hid_size_t d_len,
 	bool has_int_button = false;
 
 #define HMT_HI_ABSOLUTE(hi)	\
-	(((hi).flags & (HIO_CONST|HIO_VARIABLE|HIO_RELATIVE)) == HIO_VARIABLE)
+	((hi).usage != 0 && ((hi).flags & (HIO_VARIABLE|HIO_RELATIVE)) == HIO_VARIABLE)
 #define	HUMS_THQA_CERT	0xC5
 
 	/*


### PR DESCRIPTION
As found in the LG Gram 15Z980-R.AAS9U1:

04CA:00A0 touchpad
1FD2:7012 touchscreen

Both devices report non-absolute usages which hmt ignores. This change
accepts all defined hid_input usages rather than only absolute values
and allows these devices to work correctly.

I'm opening this as an example but I don't have other hardware I can test to validate if this is a correct change or not. I haven't found anything in the Microsoft I2C HID spec that says that these devices must or should only report absolute usages but that doesn't mean this might not hurt other devices.