### PR TITLE
Move proper hat switch handling from ps4dshock to hgame

### DIFF
--- a/hgame.c
+++ b/hgame.c
@@ -52,6 +52,8 @@ __FBSDID("$FreeBSD$");
 	{ HIDMAP_KEY_RANGE(HUP_BUTTON, number_from, number_to, code) }
 #define HGAME_MAP_ABS(usage, code)	\
 	{ HIDMAP_ABS(HUP_GENERIC_DESKTOP, HUG_##usage, code) }
+#define HGAME_MAP_GCB(usage, callback)	\
+	{ HIDMAP_ANY_CB(HUP_GENERIC_DESKTOP, HUG_##usage, callback) }
 #define HGAME_MAP_CRG(usage_from, usage_to, callback)	\
 	{ HIDMAP_ANY_CB_RANGE(HUP_GENERIC_DESKTOP,	\
 	    HUG_##usage_from, HUG_##usage_to, callback) }
@@ -66,7 +68,7 @@ static const struct hidmap_item hgame_map[] = {
 	HGAME_MAP_ABS(RX,		ABS_RX),
 	HGAME_MAP_ABS(RY,		ABS_RY),
 	HGAME_MAP_ABS(RZ,		ABS_RZ),
-	HGAME_MAP_ABS(HAT_SWITCH,	ABS_HAT0X),
+	HGAME_MAP_GCB(HAT_SWITCH,	hgame_hat_switch_cb),
 	HGAME_MAP_CRG(D_PAD_UP, D_PAD_LEFT, hgame_dpad_cb),
 	HGAME_MAP_BRG(17, 57,		BTN_TRIGGER_HAPPY),
 	HGAME_FINALCB(			hgame_final_cb),
@@ -78,6 +80,36 @@ static const struct hid_device_id hgame_devs[] = {
 	{ HID_TLC(HUP_GENERIC_DESKTOP, HUG_GAME_PAD),
 	  HID_DRIVER_INFO(HUG_GAME_PAD) },
 };
+
+int
+hgame_hat_switch_cb(HIDMAP_CB_ARGS)
+{
+	static const struct { int32_t x; int32_t y; } hat_switch_map[] = {
+	    {0, -1}, {1, -1}, {1, 0}, {1, 1}, {0, 1}, {-1, 1}, {-1, 0},
+	    {-1, -1},{0, 0}
+	};
+	struct evdev_dev *evdev = HIDMAP_CB_GET_EVDEV();
+	u_int idx;
+
+	switch (HIDMAP_CB_GET_STATE()) {
+	case HIDMAP_CB_IS_ATTACHING:
+		evdev_support_event(evdev, EV_ABS);
+		evdev_support_abs(evdev, ABS_HAT0X, -1, 1, 0, 0, 0);
+		evdev_support_abs(evdev, ABS_HAT0Y, -1, 1, 0, 0, 0);
+		break;
+
+	case HIDMAP_CB_IS_RUNNING:
+		idx = MIN(nitems(hat_switch_map) - 1, (u_int)ctx.data);
+		evdev_push_abs(evdev, ABS_HAT0X, hat_switch_map[idx].x);
+		evdev_push_abs(evdev, ABS_HAT0Y, hat_switch_map[idx].y);
+		break;
+
+	default:
+		break;
+	}
+
+	return (0);
+}
 
 /*
  * Emulate the hat switch report via the D-pad usages

--- a/hgame.h
+++ b/hgame.h
@@ -31,6 +31,7 @@
 
 #include "hidmap.h"
 
+hidmap_cb_t	hgame_hat_switch_cb;
 hidmap_cb_t	hgame_dpad_cb;
 hidmap_cb_t	hgame_final_cb;
 

--- a/ps4dshock.c
+++ b/ps4dshock.c
@@ -46,6 +46,7 @@ __FBSDID("$FreeBSD$");
 #include <dev/evdev/input.h>
 #include <dev/evdev/evdev.h>
 
+#include "hgame.h"
 #include "hid.h"
 #include "hidbus.h"
 #include "hidquirk.h"
@@ -598,7 +599,6 @@ static const uint8_t	ps4dshock_rdesc[] = {
 #define	PS4DS_OUTPUT_REPORT5_SIZE	32
 #define	PS4DS_OUTPUT_REPORT11_SIZE	78
 
-static hidmap_cb_t	ps4dshock_hat_switch_cb;
 static hidmap_cb_t	ps4dshock_final_cb;
 static hidmap_cb_t	ps4dsacc_data_cb;
 static hidmap_cb_t	ps4dsacc_tstamp_cb;
@@ -753,7 +753,7 @@ static const struct hidmap_item ps4dshock_map[] = {
 	PS4DS_MAP_BTN(13,		BTN_MODE),
 	/* Click button is handled by touchpad driver */
 	/* PS4DS_MAP_BTN(14,	BTN_LEFT), */
-	PS4DS_MAP_GCB(HAT_SWITCH,	ps4dshock_hat_switch_cb),
+	PS4DS_MAP_GCB(HAT_SWITCH,	hgame_hat_switch_cb),
 	PS4DS_FINALCB(			ps4dshock_final_cb),
 };
 static const struct hidmap_item ps4dsacc_map[] = {
@@ -796,36 +796,6 @@ static const struct hid_device_id ps4dsmtp_devs[] = {
 	{ HID_BVP(BUS_USB, USB_VENDOR_SONY, 0x9cc),
 	  HID_TLC(HUP_DIGITIZERS, HUD_TOUCHPAD) },
 };
-
-static int
-ps4dshock_hat_switch_cb(HIDMAP_CB_ARGS)
-{
-	static const struct { int32_t x; int32_t y; } hat_switch_map[] = {
-	    {0, -1}, {1, -1}, {1, 0}, {1, 1}, {0, 1}, {-1, 1}, {-1, 0},
-	    {-1, -1},{0, 0}
-	};
-	struct evdev_dev *evdev = HIDMAP_CB_GET_EVDEV();
-	u_int idx;
-
-	switch (HIDMAP_CB_GET_STATE()) {
-	case HIDMAP_CB_IS_ATTACHING:
-		evdev_support_event(evdev, EV_ABS);
-		evdev_support_abs(evdev, ABS_HAT0X, 0, -1, 1, 0, 0, 0);
-		evdev_support_abs(evdev, ABS_HAT0Y, 0, -1, 1, 0, 0, 0);
-		break;
-
-	case HIDMAP_CB_IS_RUNNING:
-		idx = MIN(nitems(hat_switch_map) - 1, (u_int)ctx.data);
-		evdev_push_abs(evdev, ABS_HAT0X, hat_switch_map[idx].x);
-		evdev_push_abs(evdev, ABS_HAT0Y, hat_switch_map[idx].y);
-		break;
-
-	default:
-		break;
-	}
-
-	return (0);
-}
 
 static int
 ps4dshock_final_cb(HIDMAP_CB_ARGS)
@@ -1445,6 +1415,7 @@ DRIVER_MODULE(ps4dshock, hidbus, ps4dshock_driver, ps4dshock_devclass, NULL, 0);
 
 MODULE_DEPEND(ps4dshock, hid, 1, 1, 1);
 MODULE_DEPEND(ps4dshock, hidmap, 1, 1, 1);
+MODULE_DEPEND(ps4dshock, hgame, 1, 1, 1);
 MODULE_DEPEND(ps4dshock, evdev, 1, 1, 1);
 MODULE_VERSION(ps4dshock, 1);
 HID_PNP_INFO(ps4dshock_devs);


### PR DESCRIPTION
Generic "DirectInput" HID gamepads need this handling too.

---

I've only tested the base version — https://reviews.freebsd.org/D31398 — building from this repo currently doesn't work for me, lots of redefinition conflicts between local `hid.h` and `/usr/src/sys/dev/hid/hid.h` :/ (ah this is #60)